### PR TITLE
Finnish and Swedish support through NatLibFi Maui

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>fi.nationallibrary</groupId>
             <artifactId>maui</artifactId>
-            <version>1.4.6-SNAPSHOT</version>
+            <version>1.4.6</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.entopix</groupId>
+            <groupId>fi.nationallibrary</groupId>
             <artifactId>maui</artifactId>
-            <version>1.3.1-cygri</version>
+            <version>1.4.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -51,11 +51,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-core</artifactId>
-            <version>2.13.0</version>
         </dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/org/topbraid/mauiserver/VocabularyResource.java
+++ b/src/main/java/org/topbraid/mauiserver/VocabularyResource.java
@@ -2,6 +2,7 @@ package org.topbraid.mauiserver;
 
 import javax.servlet.ServletContext;
 
+import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.topbraid.mauiserver.framework.Request;
@@ -14,7 +15,6 @@ import org.topbraid.mauiserver.tagger.Tagger;
 
 import com.entopix.maui.vocab.Vocabulary;
 import com.entopix.maui.vocab.VocabularyStore;
-import com.hp.hpl.jena.rdf.model.Model;
 
 public class VocabularyResource extends Resource
 		implements Gettable, Puttable, Deletable {

--- a/src/main/java/org/topbraid/mauiserver/framework/Request.java
+++ b/src/main/java/org/topbraid/mauiserver/framework/Request.java
@@ -13,6 +13,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.shared.JenaException;
 import org.topbraid.mauiserver.MauiServerException;
 import org.topbraid.mauiserver.framework.Resource.Deletable;
 import org.topbraid.mauiserver.framework.Resource.Postable;
@@ -26,9 +29,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.shared.JenaException;
 
 public class Request {
 	private final HttpServletRequest request;

--- a/src/main/java/org/topbraid/mauiserver/framework/Response.java
+++ b/src/main/java/org/topbraid/mauiserver/framework/Response.java
@@ -4,15 +4,15 @@ import java.io.IOException;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.shared.JenaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.shared.JenaException;
 
 public abstract class Response {
 	private final static Logger log = LoggerFactory.getLogger(Response.class);

--- a/src/main/java/org/topbraid/mauiserver/persistence/TaggerStore.java
+++ b/src/main/java/org/topbraid/mauiserver/persistence/TaggerStore.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.topbraid.mauiserver.MauiServerException;
@@ -17,7 +18,6 @@ import org.topbraid.mauiserver.tagger.JobReport;
 import org.topbraid.mauiserver.tagger.TaggerConfiguration;
 
 import com.entopix.maui.filters.MauiFilter;
-import com.hp.hpl.jena.rdf.model.Model;
 
 public class TaggerStore {
 	private static final Logger log = LoggerFactory.getLogger(TaggerStore.class);

--- a/src/main/java/org/topbraid/mauiserver/persistence/VocabularyStore.java
+++ b/src/main/java/org/topbraid/mauiserver/persistence/VocabularyStore.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.shared.JenaException;
-import com.hp.hpl.jena.util.FileManager;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.shared.JenaException;
+import org.apache.jena.util.FileManager;
 
 public class VocabularyStore extends FileStore<Model> {
 

--- a/src/main/java/org/topbraid/mauiserver/tagger/Tagger.java
+++ b/src/main/java/org/topbraid/mauiserver/tagger/Tagger.java
@@ -1,5 +1,6 @@
 package org.topbraid.mauiserver.tagger;
 
+import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.topbraid.mauiserver.MauiServerException;
@@ -8,7 +9,6 @@ import org.topbraid.mauiserver.persistence.TaggerStore;
 import com.entopix.maui.filters.MauiFilter;
 import com.entopix.maui.main.MauiWrapper;
 import com.entopix.maui.vocab.Vocabulary;
-import com.hp.hpl.jena.rdf.model.Model;
 
 public class Tagger {
 	private final static Logger log = LoggerFactory.getLogger(Tagger.class);

--- a/src/main/java/org/topbraid/mauiserver/tagger/TaggerConfiguration.java
+++ b/src/main/java/org/topbraid/mauiserver/tagger/TaggerConfiguration.java
@@ -12,12 +12,14 @@ import com.entopix.maui.stemmers.GermanStemmer;
 import com.entopix.maui.stemmers.PorterStemmer;
 import com.entopix.maui.stemmers.SpanishStemmer;
 import com.entopix.maui.stemmers.Stemmer;
+import com.entopix.maui.stemmers.SwedishStemmer;
 import com.entopix.maui.stopwords.Stopwords;
 import com.entopix.maui.stopwords.StopwordsEnglish;
 import com.entopix.maui.stopwords.StopwordsFinnish;
 import com.entopix.maui.stopwords.StopwordsFrench;
 import com.entopix.maui.stopwords.StopwordsGerman;
 import com.entopix.maui.stopwords.StopwordsSpanish;
+import com.entopix.maui.stopwords.StopwordsSwedish;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -51,6 +53,7 @@ public class TaggerConfiguration {
 		put("de", GermanStemmer.class);
 		put("es", SpanishStemmer.class);
 		put("fi", CachingFinnishStemmer.class);
+		put("sv", SwedishStemmer.class);
 	}};
 	
 	@SuppressWarnings("serial")
@@ -60,6 +63,7 @@ public class TaggerConfiguration {
 		put("de", StopwordsGerman.class);
 		put("es", StopwordsSpanish.class);
 		put("fi", StopwordsFinnish.class);
+		put("sv", StopwordsSwedish.class);
 	}};
 	
 	public TaggerConfiguration(String id) {

--- a/src/main/java/org/topbraid/mauiserver/tagger/TaggerConfiguration.java
+++ b/src/main/java/org/topbraid/mauiserver/tagger/TaggerConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.topbraid.mauiserver.MauiServer;
 import org.topbraid.mauiserver.MauiServerException;
 
+import com.entopix.maui.stemmers.CachingFinnishStemmer;
 import com.entopix.maui.stemmers.FrenchStemmer;
 import com.entopix.maui.stemmers.GermanStemmer;
 import com.entopix.maui.stemmers.PorterStemmer;
@@ -13,6 +14,7 @@ import com.entopix.maui.stemmers.SpanishStemmer;
 import com.entopix.maui.stemmers.Stemmer;
 import com.entopix.maui.stopwords.Stopwords;
 import com.entopix.maui.stopwords.StopwordsEnglish;
+import com.entopix.maui.stopwords.StopwordsFinnish;
 import com.entopix.maui.stopwords.StopwordsFrench;
 import com.entopix.maui.stopwords.StopwordsGerman;
 import com.entopix.maui.stopwords.StopwordsSpanish;
@@ -48,6 +50,7 @@ public class TaggerConfiguration {
 		put("fr", FrenchStemmer.class);
 		put("de", GermanStemmer.class);
 		put("es", SpanishStemmer.class);
+		put("fi", CachingFinnishStemmer.class);
 	}};
 	
 	@SuppressWarnings("serial")
@@ -56,6 +59,7 @@ public class TaggerConfiguration {
 		put("fr", StopwordsFrench.class);
 		put("de", StopwordsGerman.class);
 		put("es", StopwordsSpanish.class);
+		put("fi", StopwordsFinnish.class);
 	}};
 	
 	public TaggerConfiguration(String id) {


### PR DESCRIPTION
This pull request switched Maui to the version maintained by National Library of Finland. Main improvements:

- A variety of maintenance improvements including switching to Jena 3.6.0
- Support for Finnish and Swedish (stemmers and stopwords)
- Artifacts published on maven central and simplifies maintenance and building
