### PR TITLE
Upgrade to Jakarta Servlets and Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Maui Server provides a topic indexing service. It automatically determines the m
 
 ## Download and Installation
 
-**Requirements:** Maui Server requires a Java Servlet Container such as Apache Tomcat or Jetty to run.
+**Requirements:** Maui Server requires a Java Servlet Container such as Apache Tomcat or Jetty to run. The container must support at least Servlet Spec 6.0 or Jakarta EE 10.
 
 **Download:** Maui Server is distributed as a war file (`mauiserver-X.Y.Z.war`). It can be downloaded [here](https://github.com/TopQuadrant/MauiServer/releases). The very latest pre-release version can also be built from the source repository, see below.
 
@@ -56,6 +56,11 @@ The API root is at `/`. A small demo app is at `/app/` (requires tagger creation
 This project is licensed under the terms of the [GNU GPL v3](http://www.gnu.org/licenses/gpl.html).
 
 ## Version history
+
+### 1.5.0 (2024-04-10)
+- Upgrade to Jakarta Servlets 6.0
+- Require a servlet container compatible with Servlets 6.0, e.g., Tomcat 10
+- Require Java 17
 
 ### 1.4.0 (2023-12-18)
 - Update various libraries

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.topbraid</groupId>
     <artifactId>mauiserver</artifactId>
-    <version>1.4.0-tq</version>
+    <version>1.5.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Maui Server</name>
     <description>An HTTP wrapper around the Maui Topic Indexer</description>
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -38,9 +38,9 @@
             <version>1.4.0-tq</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -80,14 +80,30 @@
         </resources>
         <plugins>
             <plugin>
+<!--
+  We should use Jetty 12: org.eclipse.jetty.ee10:jetty-ee10-maven-plugin:12.0.8
+  because that provides jakarta.servlet-api:6.0.0 while Jetty 11
+  only provides 5.0.0. But one of Weka's transitive dependencies
+  is of type :pom: and Jetty 12 doesn't seem to support this
+  type. So we use Jetty 11 which seems to work fine. We could also
+  use jetty:run-war instead of jetty:run.
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-maven-plugin</artifactId>
+                <version>12.0.8</version>
+-->
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.53.v20231009</version>
+                <version>11.0.20</version>
                 <configuration>
                     <loginServices>
                         <loginService implementation="org.eclipse.jetty.security.HashLoginService">
                             <name>Maui Server</name>
                             <config>${project.basedir}/src/etc/realm.properties</config>
+<!-- The above works for Jetty up to 11; the below for Jetty 12
+                            <config implementation="org.eclipse.jetty.ee10.maven.plugin.MavenResource">
+                                <resourceAsString>${project.basedir}/src/etc/realm.properties</resourceAsString>
+                            </config>
+-->
                         </loginService>
                     </loginServices>
                 </configuration>

--- a/src/main/java/org/topbraid/mauiserver/AbstractJobControllerResource.java
+++ b/src/main/java/org/topbraid/mauiserver/AbstractJobControllerResource.java
@@ -1,7 +1,5 @@
 package org.topbraid.mauiserver;
 
-import javax.servlet.ServletContext;
-
 import org.topbraid.mauiserver.framework.Request;
 import org.topbraid.mauiserver.framework.Resource;
 import org.topbraid.mauiserver.framework.Resource.Deletable;
@@ -12,6 +10,8 @@ import org.topbraid.mauiserver.framework.Response.JSONResponse;
 import org.topbraid.mauiserver.tagger.AsyncJob;
 import org.topbraid.mauiserver.tagger.JobController;
 import org.topbraid.mauiserver.tagger.JobReport;
+
+import jakarta.servlet.ServletContext;
 
 /**
  * A resource in charge of a {@link JobController}.

--- a/src/main/java/org/topbraid/mauiserver/AbstractTrainingJobResource.java
+++ b/src/main/java/org/topbraid/mauiserver/AbstractTrainingJobResource.java
@@ -2,8 +2,6 @@ package org.topbraid.mauiserver;
 
 import java.util.List;
 
-import javax.servlet.ServletContext;
-
 import org.topbraid.mauiserver.framework.JsonLinesParser;
 import org.topbraid.mauiserver.framework.Request;
 import org.topbraid.mauiserver.framework.Response;
@@ -14,6 +12,8 @@ import org.topbraid.mauiserver.tagger.JobReport;
 import org.topbraid.mauiserver.tagger.Tagger;
 import org.topbraid.mauiserver.tagger.TrainingDataParser;
 import org.topbraid.mauiserver.tagger.TrainingDocument;
+
+import jakarta.servlet.ServletContext;
 
 /**
  * A resource in charge of a {@link JobController} that processes

--- a/src/main/java/org/topbraid/mauiserver/ConfigurationResource.java
+++ b/src/main/java/org/topbraid/mauiserver/ConfigurationResource.java
@@ -1,8 +1,5 @@
 package org.topbraid.mauiserver;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletResponse;
-
 import org.topbraid.mauiserver.framework.Request;
 import org.topbraid.mauiserver.framework.Resource;
 import org.topbraid.mauiserver.framework.Resource.Deletable;
@@ -15,6 +12,9 @@ import org.topbraid.mauiserver.tagger.Tagger;
 import org.topbraid.mauiserver.tagger.TaggerConfiguration;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class ConfigurationResource extends Resource
 		implements Gettable, Postable, Puttable, Deletable {

--- a/src/main/java/org/topbraid/mauiserver/CrossValidationResource.java
+++ b/src/main/java/org/topbraid/mauiserver/CrossValidationResource.java
@@ -2,13 +2,13 @@ package org.topbraid.mauiserver;
 
 import java.util.List;
 
-import javax.servlet.ServletContext;
-
 import org.topbraid.mauiserver.tagger.AsyncJob;
 import org.topbraid.mauiserver.tagger.CrossValidationJob;
 import org.topbraid.mauiserver.tagger.JobReport;
 import org.topbraid.mauiserver.tagger.Tagger;
 import org.topbraid.mauiserver.tagger.TrainingDocument;
+
+import jakarta.servlet.ServletContext;
 
 public class CrossValidationResource extends AbstractTrainingJobResource {
 	private final Tagger tagger;

--- a/src/main/java/org/topbraid/mauiserver/HomeResource.java
+++ b/src/main/java/org/topbraid/mauiserver/HomeResource.java
@@ -1,7 +1,5 @@
 package org.topbraid.mauiserver;
 
-import javax.servlet.ServletContext;
-
 import org.topbraid.mauiserver.framework.Request;
 import org.topbraid.mauiserver.framework.Resource;
 import org.topbraid.mauiserver.framework.Resource.Gettable;
@@ -15,6 +13,8 @@ import org.topbraid.mauiserver.tagger.TaggerConfiguration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import jakarta.servlet.ServletContext;
 
 public class HomeResource extends Resource implements Gettable, Postable {
 	private TaggerCollection taggers;

--- a/src/main/java/org/topbraid/mauiserver/MauiServer.java
+++ b/src/main/java/org/topbraid/mauiserver/MauiServer.java
@@ -4,8 +4,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Properties;
 
-import javax.servlet.ServletContext;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.topbraid.mauiserver.classifier.ClassifierResource;
@@ -13,6 +11,8 @@ import org.topbraid.mauiserver.framework.Resource;
 import org.topbraid.mauiserver.framework.Server;
 import org.topbraid.mauiserver.tagger.Tagger;
 import org.topbraid.mauiserver.tagger.TaggerCollection;
+
+import jakarta.servlet.ServletContext;
 
 public class MauiServer implements Server {
 	public final static Logger log = LoggerFactory.getLogger(MauiServer.class);

--- a/src/main/java/org/topbraid/mauiserver/SuggestResource.java
+++ b/src/main/java/org/topbraid/mauiserver/SuggestResource.java
@@ -1,7 +1,5 @@
 package org.topbraid.mauiserver;
 
-import javax.servlet.ServletContext;
-
 import org.topbraid.mauiserver.framework.Request;
 import org.topbraid.mauiserver.framework.Resource;
 import org.topbraid.mauiserver.framework.Resource.Gettable;
@@ -10,6 +8,8 @@ import org.topbraid.mauiserver.framework.Response;
 import org.topbraid.mauiserver.framework.Response.JSONResponse;
 import org.topbraid.mauiserver.tagger.RecommendationResult;
 import org.topbraid.mauiserver.tagger.Tagger;
+
+import jakarta.servlet.ServletContext;
 
 public class SuggestResource extends Resource implements Gettable, Postable {
 	private final Tagger tagger;

--- a/src/main/java/org/topbraid/mauiserver/TaggerResource.java
+++ b/src/main/java/org/topbraid/mauiserver/TaggerResource.java
@@ -4,8 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 
-import javax.servlet.ServletContext;
-
 import org.topbraid.mauiserver.framework.Request;
 import org.topbraid.mauiserver.framework.Resource;
 import org.topbraid.mauiserver.framework.Resource.Deletable;
@@ -17,6 +15,8 @@ import org.topbraid.mauiserver.tagger.TaggerCollection;
 
 import com.entopix.maui.vocab.VocabularyStore;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import jakarta.servlet.ServletContext;
 
 public class TaggerResource extends Resource implements Gettable, Deletable {
 	private final TaggerCollection taggers;

--- a/src/main/java/org/topbraid/mauiserver/TrainingResource.java
+++ b/src/main/java/org/topbraid/mauiserver/TrainingResource.java
@@ -2,8 +2,6 @@ package org.topbraid.mauiserver;
 
 import java.util.List;
 
-import javax.servlet.ServletContext;
-
 import org.topbraid.mauiserver.framework.Request;
 import org.topbraid.mauiserver.framework.Response;
 import org.topbraid.mauiserver.framework.Response.JSONResponse;
@@ -12,6 +10,8 @@ import org.topbraid.mauiserver.tagger.JobReport;
 import org.topbraid.mauiserver.tagger.Tagger;
 import org.topbraid.mauiserver.tagger.TrainingDocument;
 import org.topbraid.mauiserver.tagger.TrainingJob;
+
+import jakarta.servlet.ServletContext;
 
 public class TrainingResource extends AbstractTrainingJobResource {
 	private final Tagger tagger;

--- a/src/main/java/org/topbraid/mauiserver/VocabularyResource.java
+++ b/src/main/java/org/topbraid/mauiserver/VocabularyResource.java
@@ -1,7 +1,6 @@
 package org.topbraid.mauiserver;
 
-import javax.servlet.ServletContext;
-
+import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.topbraid.mauiserver.framework.Request;
@@ -14,7 +13,8 @@ import org.topbraid.mauiserver.tagger.Tagger;
 
 import com.entopix.maui.vocab.Vocabulary;
 import com.entopix.maui.vocab.VocabularyStore;
-import org.apache.jena.rdf.model.Model;
+
+import jakarta.servlet.ServletContext;
 
 public class VocabularyResource extends Resource
 		implements Gettable, Puttable, Deletable {

--- a/src/main/java/org/topbraid/mauiserver/classifier/ClassifierResource.java
+++ b/src/main/java/org/topbraid/mauiserver/classifier/ClassifierResource.java
@@ -2,8 +2,6 @@ package org.topbraid.mauiserver.classifier;
 
 import java.util.Iterator;
 
-import javax.servlet.ServletContext;
-
 import org.topbraid.mauiserver.framework.Request;
 import org.topbraid.mauiserver.framework.Resource;
 import org.topbraid.mauiserver.framework.Resource.Deletable;
@@ -17,6 +15,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+
+import jakarta.servlet.ServletContext;
 
 /**
  * Example Ajax calls:

--- a/src/main/java/org/topbraid/mauiserver/framework/Request.java
+++ b/src/main/java/org/topbraid/mauiserver/framework/Request.java
@@ -9,10 +9,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.shared.JenaException;
 import org.topbraid.mauiserver.MauiServerException;
 import org.topbraid.mauiserver.framework.Resource.Deletable;
 import org.topbraid.mauiserver.framework.Resource.Postable;
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.shared.JenaException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class Request {
 	private final HttpServletRequest request;

--- a/src/main/java/org/topbraid/mauiserver/framework/Resource.java
+++ b/src/main/java/org/topbraid/mauiserver/framework/Resource.java
@@ -1,6 +1,6 @@
 package org.topbraid.mauiserver.framework;
 
-import javax.servlet.ServletContext;
+import jakarta.servlet.ServletContext;
 
 public abstract class Resource {
 	private final ServletContext context;

--- a/src/main/java/org/topbraid/mauiserver/framework/Response.java
+++ b/src/main/java/org/topbraid/mauiserver/framework/Response.java
@@ -2,17 +2,17 @@ package org.topbraid.mauiserver.framework;
 
 import java.io.IOException;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.shared.JenaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.shared.JenaException;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 public abstract class Response {
 	private final static Logger log = LoggerFactory.getLogger(Response.class);

--- a/src/main/java/org/topbraid/mauiserver/framework/RootServlet.java
+++ b/src/main/java/org/topbraid/mauiserver/framework/RootServlet.java
@@ -2,12 +2,6 @@ package org.topbraid.mauiserver.framework;
 
 import java.io.IOException;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.topbraid.mauiserver.MauiServer;
@@ -15,6 +9,12 @@ import org.topbraid.mauiserver.framework.Resource.Deletable;
 import org.topbraid.mauiserver.framework.Resource.Gettable;
 import org.topbraid.mauiserver.framework.Resource.Postable;
 import org.topbraid.mauiserver.framework.Resource.Puttable;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("serial")
 public class RootServlet extends HttpServlet {

--- a/src/main/java/org/topbraid/mauiserver/framework/Server.java
+++ b/src/main/java/org/topbraid/mauiserver/framework/Server.java
@@ -1,6 +1,6 @@
 package org.topbraid.mauiserver.framework;
 
-import javax.servlet.ServletContext;
+import jakarta.servlet.ServletContext;
 
 public interface Server {
 


### PR DESCRIPTION
- Change version to `1.5.0-SNAPSHOT`
- Require Java 17, like EDG
- Upgrade to Servlets 6.0, like EDG
- Mechanically change package names from `javax.servlet` to `jakarta.servlet` as required by Servlets 6
- Upgrade Jetty Maven Plugin to a version that supports Servlets 6.0. This should be Jetty 12, but `jetty:run` fails there. So we use Jetty 11 which only supports Servlets 5, but it works.